### PR TITLE
Support multipart

### DIFF
--- a/src/rgw/rgw_sal_daos.cc
+++ b/src/rgw/rgw_sal_daos.cc
@@ -1872,14 +1872,12 @@ int DaosMultipartUpload::init(const DoutPrefixProvider* dpp, optional_yield y,
     return ret;
   }
 
-  std::unique_ptr<rgw::sal::Object> obj = get_meta_obj();
-
   // Create an initial entry in the bucket. The entry will be
   // updated when multipart upload is completed, for example,
   // size, etag etc.
   bufferlist bl;
   rgw_bucket_dir_entry ent;
-  obj->get_key().get_index_key(&ent.key);
+  ent.key.name = oid;
   ent.meta.owner = owner.get_id().to_str();
   ent.meta.category = RGWObjCategory::MultiMeta;
   ent.meta.mtime = ceph::real_clock::now();

--- a/src/rgw/rgw_sal_daos.cc
+++ b/src/rgw/rgw_sal_daos.cc
@@ -1727,9 +1727,10 @@ int DaosAtomicWriter::process(bufferlist&& data, uint64_t offset) {
   }
 
   // XXX: Combine multiple streams into one as motr does
+  uint64_t data_size =  data.length();
   ret = obj.write(dpp, std::move(data), offset);
   if (ret == 0) {
-    total_data_size += data.length();
+    total_data_size += data_size;
   }
   return ret;
 }
@@ -2439,9 +2440,10 @@ int DaosMultipartWriter::process(bufferlist&& data, uint64_t offset) {
   }
 
   // XXX: Combine multiple streams into one as motr does
+  uint64_t data_size =  data.length();
   ret = part_obj->write(dpp, std::move(data), offset);
   if (ret == 0) {
-    actual_part_size += data.length();
+    actual_part_size += data_size;
   }
   return ret;
 }

--- a/src/rgw/rgw_sal_daos.cc
+++ b/src/rgw/rgw_sal_daos.cc
@@ -50,11 +50,13 @@ using ::ceph::encode;
 #define USERS_DIR "users"
 #define EMAILS_DIR "emails"
 #define ACCESS_KEYS_DIR "access_keys"
+#define MULTIPART_DIR "multipart"
 
 static const std::string METADATA_DIRS[] = {
   USERS_DIR,
   EMAILS_DIR,
-  ACCESS_KEYS_DIR
+  ACCESS_KEYS_DIR,
+  MULTIPART_DIR
 };
 
 int DaosUser::list_buckets(const DoutPrefixProvider* dpp, const string& marker,
@@ -162,7 +164,7 @@ int DaosUser::create_bucket(
     ret = dfs_cont_create_with_label(store->poh, bucket->get_name().c_str(),
                                      nullptr, nullptr, nullptr, nullptr);
     ldpp_dout(dpp, 20) << "DEBUG: dfs_cont_create_with_label ret=" << ret
-                       << " name=" << bucket->get_name().c_str() << dendl;
+                       << " name=" << bucket->get_name() << dendl;
     if (ret != 0) {
       ldpp_dout(dpp, 0) << "ERROR: dfs_cont_create_with_label failed! ret="
                         << ret << dendl;
@@ -172,6 +174,17 @@ int DaosUser::create_bucket(
     if (ret != 0) {
       ldpp_dout(dpp, 0) << "ERROR: failed to put bucket info! ret=" << ret
                         << dendl;
+      return ret;
+    }
+
+    // Create multipart index
+    ret = dfs_mkdir(store->meta_dfs, store->dirs[MULTIPART_DIR],
+                    bucket->get_name().c_str(), mode, 0);
+    ldout(cctx, 20) << "DEBUG: multipart index dfs_mkdir bucket="
+                    << bucket->get_name() << " ret=" << ret << dendl;
+    if (ret != 0 && ret != EEXIST) {
+      ldout(cctx, 0) << "ERROR: multipart index creation failed! dfs_mkdir ret="
+                     << ret << dendl;
       return ret;
     }
   } else {
@@ -789,11 +802,13 @@ int DaosBucket::list_multiparts(
     const string& delim, const int& max_uploads,
     vector<std::unique_ptr<MultipartUpload>>& uploads,
     map<string, bool>* common_prefixes, bool* is_truncated) {
+  // TODO
   return 0;
 }
 
 int DaosBucket::abort_multiparts(const DoutPrefixProvider* dpp,
                                  CephContext* cct) {
+  // TODO
   return 0;
 }
 

--- a/src/rgw/rgw_sal_daos.cc
+++ b/src/rgw/rgw_sal_daos.cc
@@ -864,8 +864,8 @@ int DaosBucket::list_multiparts(
     return ret;
   }
 
-  if (!daos_anchor_is_eof(&anchor)) {
-    is_truncated = true;
+  if (is_truncated && !daos_anchor_is_eof(&anchor)) {
+    *is_truncated = true;
   }
 
   for (uint32_t i = 0; i < nr; i++) {
@@ -916,7 +916,7 @@ int DaosBucket::list_multiparts(
       // Add common prefixes
       if (common_prefixes && !delim.empty()) {
         // Name key has delim after the prefix
-        const int delim_pos = name.find(delim, prefix.size());
+        const size_t delim_pos = name.find(delim, prefix.size());
         if (delim_pos != std::string::npos) {
           string prefix_key = name.substr(0, delim_pos + delim.length());
           (*common_prefixes)[prefix_key] = true;
@@ -929,11 +929,11 @@ int DaosBucket::list_multiparts(
     ldpp_dout(dpp, 20) << "DEBUG: dfs_release upload_dir ret=" << ret << dendl;
   }
 
-  // Sort results
-  std::sort(results.begin(), results.end(), compare_multipart_upload);
+  // Sort uploads
+  std::sort(uploads.begin(), uploads.end(), compare_multipart_upload);
 
-  ret = dfs_release(dir_obj);
-  ldpp_dout(dpp, 20) << "DEBUG: dfs_release dir_obj ret=" << ret << dendl;
+  ret = dfs_release(multipart_dir);
+  ldpp_dout(dpp, 20) << "DEBUG: dfs_release multipart_dir ret=" << ret << dendl;
 
   ret = close(dpp);
 

--- a/src/rgw/rgw_sal_daos.cc
+++ b/src/rgw/rgw_sal_daos.cc
@@ -1838,11 +1838,6 @@ std::unique_ptr<rgw::sal::Object> DaosMultipartUpload::get_meta_obj() {
   return bucket->get_object(rgw_obj_key(get_meta(), string(), mp_ns));
 }
 
-std::unique_ptr<DaosObject> DaosMultipartUpload::get_daos_object() {
-  return std::make_unique<DaosObject>(
-      this->store, rgw_obj_key(get_key(), string(), mp_ns), this->bucket);
-}
-
 int DaosMultipartUpload::init(const DoutPrefixProvider* dpp, optional_yield y,
                               RGWObjectCtx* obj_ctx, ACLOwner& _owner,
                               rgw_placement_rule& dest_placement,
@@ -2244,7 +2239,7 @@ int DaosMultipartUpload::complete(
   encode(attrs, wbl);
 
   // Open object
-  std::unique_ptr<DaosObject> obj = get_daos_object();
+  DaosObject* obj = static_cast<DaosObject*>(target_obj);
   ret = obj->open(dpp, DaosObjectOpen::Create);
   if (ret != 0) {
     ldpp_dout(dpp, 0) << "ERROR: failed to open daos object ("

--- a/src/rgw/rgw_sal_daos.cc
+++ b/src/rgw/rgw_sal_daos.cc
@@ -2240,6 +2240,7 @@ int DaosMultipartUpload::get_info(const DoutPrefixProvider* dpp,
   auto iter = bl.cbegin();
   ent.decode(iter);
   decode(decoded_attrs, iter);
+  ldpp_dout(dpp, 20) << "DEBUG: decoded_attrs=" << attrs << dendl;
 
   if (attrs) {
     *attrs = decoded_attrs;
@@ -2262,13 +2263,16 @@ std::unique_ptr<Writer> DaosMultipartUpload::get_writer(
     std::unique_ptr<rgw::sal::Object> _head_obj, const rgw_user& owner,
     RGWObjectCtx& obj_ctx, const rgw_placement_rule* ptail_placement_rule,
     uint64_t part_num, const std::string& part_num_str) {
+  ldpp_dout(dpp, 20) << "DaosMultipartUpload::get_writer(): enter part="
+                     << part_num << " head_obj=" << _head_obj << dendl;
   return std::make_unique<DaosMultipartWriter>(
       dpp, y, this, std::move(_head_obj), store, owner, obj_ctx,
       ptail_placement_rule, part_num, part_num_str);
 }
 
 int DaosMultipartWriter::prepare(optional_yield y) {
-  ldpp_dout(dpp, 20) << "DaosMultipartWriter::prepare(): enter" << dendl;
+  ldpp_dout(dpp, 20) << "DaosMultipartWriter::prepare(): enter part="
+                     << part_num_str << dendl;
 
   DaosObject* obj = get_daos_meta_obj();
   int ret = obj->open(dpp, false);
@@ -2315,6 +2319,8 @@ int DaosMultipartWriter::prepare(optional_yield y) {
 }
 
 int DaosMultipartWriter::process(bufferlist&& data, uint64_t offset) {
+  ldpp_dout(dpp, 20) << "DaosMultipartWriter::process(): enter part="
+                     << part_num_str << " offset=" << offset << dendl;
   if (data.length() == 0) {
     return 0;
   }
@@ -2345,7 +2351,8 @@ int DaosMultipartWriter::complete(
     ceph::real_time delete_at, const char* if_match, const char* if_nomatch,
     const std::string* user_data, rgw_zone_set* zones_trace, bool* canceled,
     optional_yield y) {
-  ldpp_dout(dpp, 20) << "DaosMultipartWriter::complete(): enter" << dendl;
+  ldpp_dout(dpp, 20) << "DaosMultipartWriter::complete(): enter part="
+                     << part_num_str << dendl;
 
   // Close writing on object
   get_daos_meta_obj()->close(dpp);

--- a/src/rgw/rgw_sal_daos.cc
+++ b/src/rgw/rgw_sal_daos.cc
@@ -2316,13 +2316,13 @@ std::string DaosStore::get_cluster_id(const DoutPrefixProvider* dpp,
 extern "C" {
 
 void* newDaosStore(CephContext* cct) {
-  int rc = -1;
+  int ret = -1;
   rgw::sal::DaosStore* store = new rgw::sal::DaosStore(cct);
 
   if (store) {
-    rc = store->initialize();
-    if (rc != 0) {
-      ldout(cct, 0) << "ERROR: store->initialize() failed: " << rc << dendl;
+    ret = store->initialize();
+    if (ret != 0) {
+      ldout(cct, 0) << "ERROR: store->initialize() failed: " << ret << dendl;
       store->finalize();
       delete store;
       return nullptr;

--- a/src/rgw/rgw_sal_daos.cc
+++ b/src/rgw/rgw_sal_daos.cc
@@ -1752,7 +1752,7 @@ int DaosAtomicWriter::complete(
   // other attrs.
   obj.get_key().get_index_key(&ent.key);
   ent.meta.size = total_data_size;
-  ent.meta.accounted_size = total_data_size;
+  ent.meta.accounted_size = accounted_size;
   ent.meta.mtime =
       real_clock::is_zero(set_mtime) ? ceph::real_clock::now() : set_mtime;
   ent.meta.etag = etag;

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -522,7 +522,7 @@ class DaosObject : public Object {
                                   bool must_exist, optional_yield y) override;
 
   bool is_open() { return _is_open; };
-  int open(const DoutPrefixProvider* dpp, bool create);
+  int open(const DoutPrefixProvider* dpp, bool create, bool exclusive = false);
   int close(const DoutPrefixProvider* dpp);
   DaosBucket* get_daos_bucket() {
     return static_cast<DaosBucket*>(get_bucket());

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -583,19 +583,13 @@ class DaosMultipartWriter : public Writer {
   rgw::sal::DaosStore* store;
 
   // Uploaded Object.
-  std::unique_ptr<rgw::sal::Object> meta_obj;
+  std::unique_ptr<DaosObject> part_obj;
   std::string upload_id;
 
   // Part parameters.
   const uint64_t part_num;
   const std::string part_num_str;
   uint64_t actual_part_size = 0;
-
-  dfs_obj_t* part_dfs_obj;
-
-  DaosObject* get_daos_meta_obj() {
-    return static_cast<DaosObject*>(meta_obj.get());
-  }
 
  public:
   DaosMultipartWriter(const DoutPrefixProvider* dpp, optional_yield y,

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -708,7 +708,6 @@ class DaosMultipartUpload : public MultipartUpload {
       std::unique_ptr<rgw::sal::Object> _head_obj, const rgw_user& owner,
       RGWObjectCtx& obj_ctx, const rgw_placement_rule* ptail_placement_rule,
       uint64_t part_num, const std::string& part_num_str) override;
-  std::unique_ptr<DaosObject> get_daos_object();
   DaosBucket* get_daos_bucket() { return static_cast<DaosBucket*>(bucket); }
 };
 

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -581,6 +581,20 @@ class DaosMultipartWriter : public Writer {
  protected:
   rgw::sal::DaosStore* store;
 
+  // Head object.
+  std::unique_ptr<rgw::sal::Object> head_obj;
+
+  // Part parameters.
+  const uint64_t part_num;
+  const std::string part_num_str;
+  uint64_t actual_part_size = 0;
+
+  dfs_obj_t* part_dfs_obj;
+
+  DaosObject* get_daos_head_obj() {
+    return static_cast<DaosObject*>(head_obj.get());
+  }
+
  public:
   DaosMultipartWriter(const DoutPrefixProvider* dpp, optional_yield y,
                       MultipartUpload* upload,
@@ -589,7 +603,11 @@ class DaosMultipartWriter : public Writer {
                       RGWObjectCtx& obj_ctx,
                       const rgw_placement_rule* ptail_placement_rule,
                       uint64_t _part_num, const std::string& part_num_str)
-      : Writer(dpp, y), store(_store) {}
+      : Writer(dpp, y),
+        store(_store),
+        head_obj(std::move(_head_obj)),
+        part_num(_part_num),
+        part_num_str(part_num_str) {}
   ~DaosMultipartWriter() = default;
 
   // prepare to start processing object data

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -699,7 +699,6 @@ class DaosMultipartUpload : public MultipartUpload {
       std::unique_ptr<rgw::sal::Object> _head_obj, const rgw_user& owner,
       RGWObjectCtx& obj_ctx, const rgw_placement_rule* ptail_placement_rule,
       uint64_t part_num, const std::string& part_num_str) override;
-  int delete_parts(const DoutPrefixProvider* dpp);
 };
 
 class DaosStore : public Store {

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -715,7 +715,7 @@ class DaosStore : public Store {
   /** Metadata bucket handle */
   daos_handle_t meta_coh;
   /** Metadata dfs handle */
-  dfs_t* meta_dfs;
+  dfs_t* meta_dfs = nullptr;
   /** Metadata index directories */
   std::map<std::string, dfs_obj_t*> dirs;
 

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -383,6 +383,15 @@ class DaosOIDCProvider : public RGWOIDCProvider {
   void decode(bufferlist::const_iterator& bl) { RGWOIDCProvider::decode(bl); }
 };
 
+enum class DaosObjectOpen {
+  // Only lookup the object, do not create
+  Lookup,
+  // Create the object, truncate if exists
+  Create,
+  // Create the object, do not create parent directories, truncate if exists
+  CreateNoDir
+};
+
 class DaosObject : public Object {
  private:
   DaosStore* store;
@@ -525,7 +534,7 @@ class DaosObject : public Object {
                                   bool must_exist, optional_yield y) override;
 
   bool is_open() { return _is_open; };
-  int open(const DoutPrefixProvider* dpp, bool create, bool exclusive = false);
+  int open(const DoutPrefixProvider* dpp, DaosObjectOpen open_flag);
   int close(const DoutPrefixProvider* dpp);
   int write(const DoutPrefixProvider* dpp, bufferlist&& data, uint64_t offset);
   DaosBucket* get_daos_bucket() {

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -693,6 +693,7 @@ class DaosMultipartUpload : public MultipartUpload {
       std::unique_ptr<rgw::sal::Object> _head_obj, const rgw_user& owner,
       RGWObjectCtx& obj_ctx, const rgw_placement_rule* ptail_placement_rule,
       uint64_t part_num, const std::string& part_num_str) override;
+  std::unique_ptr<DaosObject> get_obj();
 };
 
 class DaosStore : public Store {

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -524,6 +524,7 @@ class DaosObject : public Object {
   bool is_open() { return _is_open; };
   int open(const DoutPrefixProvider* dpp, bool create, bool exclusive = false);
   int close(const DoutPrefixProvider* dpp);
+  int write(const DoutPrefixProvider* dpp, bufferlist&& data, uint64_t offset);
   DaosBucket* get_daos_bucket() {
     return static_cast<DaosBucket*>(get_bucket());
   }

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -582,8 +582,9 @@ class DaosMultipartWriter : public Writer {
  protected:
   rgw::sal::DaosStore* store;
 
-  // Head object.
-  std::unique_ptr<rgw::sal::Object> head_obj;
+  // Uploaded Object.
+  std::unique_ptr<rgw::sal::Object> meta_obj;
+  std::string upload_id;
 
   // Part parameters.
   const uint64_t part_num;
@@ -592,7 +593,7 @@ class DaosMultipartWriter : public Writer {
 
   dfs_obj_t* part_dfs_obj;
 
-  DaosObject* get_daos_head_obj() {
+  DaosObject* get_daos_meta_obj() {
     return static_cast<DaosObject*>(head_obj.get());
   }
 
@@ -605,8 +606,9 @@ class DaosMultipartWriter : public Writer {
                       const rgw_placement_rule* ptail_placement_rule,
                       uint64_t _part_num, const std::string& part_num_str)
       : Writer(dpp, y),
+        meta_obj(upload->get_meta_obj()),
+        upload_id(upload->get_upload_id()),
         store(_store),
-        head_obj(std::move(_head_obj)),
         part_num(_part_num),
         part_num_str(part_num_str) {}
   ~DaosMultipartWriter() = default;

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -706,6 +706,7 @@ class DaosStore : public Store {
   std::string luarocks_path;
   DaosZone zone;
   RGWSyncModuleInstanceRef sync_module;
+  std::unique_ptr<DaosBucket> metadata_bucket;
 
  public:
   /** UUID of the pool */
@@ -872,6 +873,8 @@ class DaosStore : public Store {
 
   int initialize(void);
   int read_user(const DoutPrefixProvider* dpp, std::string parent, std::string name, DaosUserInfo* duinfo);
+  DaosBucket* get_metadata_bucket();
+  std::unique_ptr<DaosObject> get_part_object(std::string upload_id, std::string part_num_str);
 };
 
 }  // namespace rgw::sal

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -594,7 +594,7 @@ class DaosMultipartWriter : public Writer {
   dfs_obj_t* part_dfs_obj;
 
   DaosObject* get_daos_meta_obj() {
-    return static_cast<DaosObject*>(head_obj.get());
+    return static_cast<DaosObject*>(meta_obj.get());
   }
 
  public:
@@ -606,9 +606,9 @@ class DaosMultipartWriter : public Writer {
                       const rgw_placement_rule* ptail_placement_rule,
                       uint64_t _part_num, const std::string& part_num_str)
       : Writer(dpp, y),
+        store(_store),
         meta_obj(upload->get_meta_obj()),
         upload_id(upload->get_upload_id()),
-        store(_store),
         part_num(_part_num),
         part_num_str(part_num_str) {}
   ~DaosMultipartWriter() = default;


### PR DESCRIPTION
Fixes #19 

## Design Summary
### Multipart upload initiation
- Generate a unique `multipart_upload_id` that identifies the upload
- Create the directory `upload_dir = multipart/<bucket_name>/<multipart_upload_id>` in the `_METADATA` bucket
- Add any metadata and attributes related to the upload in the `rgw_entry xattr` of the `upload_dir` directory

### Parts upload
- Write the data of each part to an object under `<upload_dir>/<part_id>`
- Metadata about each part is stored in the xattr `rgw_part` of the part object

### Multipart upload completion
- Create the object under the correct key and bucket, creating any missing directories in the process
- Copy data from each part to the created object ordered by `part_id`
- Move the metadata and attributes from the upload directory to the object
- Delete the `upload_dir` directory created during initiation, including the parts.