### PR TITLE
Fix versioning

### DIFF
--- a/src/rgw/rgw_sal_daos.cc
+++ b/src/rgw/rgw_sal_daos.cc
@@ -1542,6 +1542,7 @@ DaosObject::DaosDeleteOp::DaosDeleteOp(DaosObject* _source, RGWObjectCtx* _rctx)
 // backend process the params.
 // 2. Delete an object when its versioning is turned on.
 // 3. Handle empty directories
+// 4. Fail when file doesn't exist
 int DaosObject::DaosDeleteOp::delete_obj(const DoutPrefixProvider* dpp,
                                          optional_yield y) {
   ldpp_dout(dpp, 20) << "DaosDeleteOp::delete_obj "
@@ -2068,7 +2069,7 @@ int DaosMultipartUpload::list_parts(const DoutPrefixProvider* dpp,
     // The entry is a regular file, read the xattr and add to objs
     vector<uint8_t> value(DFS_MAX_XATTR_LEN);
     size_t size = value.size();
-    dfs_getxattr(store->meta_dfs, part_obj, RGW_PART_XATTR, value.data(),
+    ret = dfs_getxattr(store->meta_dfs, part_obj, RGW_PART_XATTR, value.data(),
                  &size);
     ldpp_dout(dpp, 20) << "DEBUG: dfs_getxattr entry=" << part_name
                        << " xattr=" << RGW_PART_XATTR << dendl;

--- a/src/rgw/rgw_sal_daos.cc
+++ b/src/rgw/rgw_sal_daos.cc
@@ -970,7 +970,7 @@ int DaosBucket::list_multiparts(
     if (ret != 0) {
       ldpp_dout(dpp, 0) << "ERROR: no dirent, skipping upload_id=" << upload_id
                         << dendl;
-      dfs_release(upload_dir);
+      ret = dfs_release(upload_dir);
       continue;
     }
 
@@ -2178,7 +2178,7 @@ int DaosMultipartUpload::list_parts(const DoutPrefixProvider* dpp,
     if (ret != 0) {
       ldpp_dout(dpp, 0) << "ERROR: no part info, skipping part=" << part_name
                         << dendl;
-      dfs_release(part_obj);
+      ret = dfs_release(part_obj);
       continue;
     }
 
@@ -2217,8 +2217,8 @@ int DaosMultipartUpload::list_parts(const DoutPrefixProvider* dpp,
     *next_marker = last_num;
   }
 
-  dfs_release(upload_dir);
-  dfs_release(multipart_dir);
+  ret = dfs_release(upload_dir);
+  ret = dfs_release(multipart_dir);
   return ret;
 }
 

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -538,6 +538,7 @@ class DaosObject : public Object {
   int close(const DoutPrefixProvider* dpp);
   int write(const DoutPrefixProvider* dpp, bufferlist&& data, uint64_t offset);
   int read(const DoutPrefixProvider* dpp, bufferlist& data, uint64_t offset, uint64_t& size);
+  int mark_as_latest(const DoutPrefixProvider *dpp)
   DaosBucket* get_daos_bucket() {
     return static_cast<DaosBucket*>(get_bucket());
   }

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -529,7 +529,7 @@ class DaosObject : public Object {
   int lookup(const DoutPrefixProvider* dpp, mode_t* mode = nullptr);
   // Create the object, truncate if exists
   int create(const DoutPrefixProvider* dpp, const bool create_parents = true,
-             const string link_to = "");
+             const std::string link_to = "");
   // Release the daos resources
   int close(const DoutPrefixProvider* dpp);
   // Write to object starting from offset

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -528,7 +528,8 @@ class DaosObject : public Object {
   // Only lookup the object, do not create
   int lookup(const DoutPrefixProvider* dpp, mode_t* mode = nullptr);
   // Create the object, truncate if exists
-  int create(const DoutPrefixProvider* dpp, const bool create_parents = true);
+  int create(const DoutPrefixProvider* dpp, const bool create_parents = true,
+             const string link_to = "");
   // Release the daos resources
   int close(const DoutPrefixProvider* dpp);
   // Write to object starting from offset

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -526,7 +526,7 @@ class DaosObject : public Object {
 
   bool is_open() { return _is_open; };
   // Only lookup the object, do not create
-  int lookup(const DoutPrefixProvider* dpp);
+  int lookup(const DoutPrefixProvider* dpp, mode_t* mode = nullptr);
   // Create the object, truncate if exists
   int create(const DoutPrefixProvider* dpp, const bool create_parents = true);
   // Release the daos resources
@@ -536,9 +536,17 @@ class DaosObject : public Object {
   // Read size bytes from object starting from offset
   int read(const DoutPrefixProvider* dpp, bufferlist& data, uint64_t offset,
            uint64_t& size);
+  // Get the object's dirent and attrs
+  int get_dir_entry_attrs(const DoutPrefixProvider* dpp,
+                          rgw_bucket_dir_entry* ent, Attrs* getattrs = nullptr,
+                          multipart_upload_info* upload_info = nullptr);
+  // Set the object's dirent and attrs
+  int set_dir_entry_attrs(const DoutPrefixProvider* dpp,
+                          rgw_bucket_dir_entry* ent, Attrs* setattrs = nullptr,
+                          multipart_upload_info* upload_info = nullptr);
   // Marks this DAOS object as being the latest version and unmarks all other
   // versions as latest
-  int mark_as_latest(const DoutPrefixProvider* dpp);
+  int mark_as_latest(const DoutPrefixProvider* dpp, ceph::real_time set_mtime);
   // get_bucket casted as DaosBucket*
   DaosBucket* get_daos_bucket() {
     return static_cast<DaosBucket*>(get_bucket());

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -383,15 +383,6 @@ class DaosOIDCProvider : public RGWOIDCProvider {
   void decode(bufferlist::const_iterator& bl) { RGWOIDCProvider::decode(bl); }
 };
 
-enum class DaosObjectOpen {
-  // Only lookup the object, do not create
-  Lookup,
-  // Create the object, truncate if exists
-  Create,
-  // Create the object, do not create parent directories, truncate if exists
-  CreateNoDir
-};
-
 class DaosObject : public Object {
  private:
   DaosStore* store;
@@ -534,11 +525,21 @@ class DaosObject : public Object {
                                   bool must_exist, optional_yield y) override;
 
   bool is_open() { return _is_open; };
-  int open(const DoutPrefixProvider* dpp, DaosObjectOpen open_flag);
+  // Only lookup the object, do not create
+  int lookup(const DoutPrefixProvider* dpp);
+  // Create the object, truncate if exists
+  int create(const DoutPrefixProvider* dpp, const bool create_parents = true);
+  // Release the daos resources
   int close(const DoutPrefixProvider* dpp);
+  // Write to object starting from offset
   int write(const DoutPrefixProvider* dpp, bufferlist&& data, uint64_t offset);
-  int read(const DoutPrefixProvider* dpp, bufferlist& data, uint64_t offset, uint64_t& size);
-  int mark_as_latest(const DoutPrefixProvider *dpp)
+  // Read size bytes from object starting from offset
+  int read(const DoutPrefixProvider* dpp, bufferlist& data, uint64_t offset,
+           uint64_t& size);
+  // Marks this DAOS object as being the latest version and unmarks all other
+  // versions as latest
+  int mark_as_latest(const DoutPrefixProvider* dpp);
+  // get_bucket casted as DaosBucket*
   DaosBucket* get_daos_bucket() {
     return static_cast<DaosBucket*>(get_bucket());
   }


### PR DESCRIPTION
- Fix errors in versioning. 
- Separate `DaosObject::open` into `DaosObject::create` and `DaosObject::lookup`
- Use `fs::path` for path operations
- Handle versioning in multipart upload
- Refactor `dfs_[get|set]xattr` into `[get|set]_dir_entry_attrs`