### PR TITLE
Clone crash during s3

### DIFF
--- a/src/rgw/rgw_sal_daos.cc
+++ b/src/rgw/rgw_sal_daos.cc
@@ -1275,7 +1275,7 @@ int DaosObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs,
   }
 
   // Update object metadata
-  Attrs updateattrs = setattrs ? attrs : *setattrs;
+  Attrs updateattrs = setattrs == nullptr ? attrs : *setattrs;
   if (delattrs) {
     for (auto const& [attr, attrval] : *delattrs) {
       updateattrs.erase(attr);

--- a/src/rgw/rgw_sal_daos.cc
+++ b/src/rgw/rgw_sal_daos.cc
@@ -1236,6 +1236,8 @@ int DaosObject::get_obj_state(const DoutPrefixProvider* dpp,
                               bool follow_olh) {
   // Get object's metadata (those stored in rgw_bucket_dir_entry)
   rgw_bucket_dir_entry ent;
+  *_state = &state;   // state is required even if a failure occurs
+
   int ret = get_dir_entry_attrs(dpp, &ent);
   if (ret != 0) {
     return ret;
@@ -1254,8 +1256,6 @@ int DaosObject::get_obj_state(const DoutPrefixProvider* dpp,
                      << dendl;
   etag_bl.append(etag);
   state.attrset[RGW_ATTR_ETAG] = etag_bl;
-  *_state = &state;
-
   return 0;
 }
 

--- a/src/rgw/rgw_sal_daos.cc
+++ b/src/rgw/rgw_sal_daos.cc
@@ -2864,15 +2864,19 @@ std::unique_ptr<Object> DaosStore::get_object(const rgw_obj_key& k) {
   return std::make_unique<DaosObject>(this, k);
 }
 
+inline std::ostream& operator<<(std::ostream& out, const rgw_user * u) {
+  std::string s;
+  if (u != nullptr)
+    u->to_str(s);
+  else
+    s = "(nullptr)";
+  return out << s;
+}
+
 int DaosStore::get_bucket(const DoutPrefixProvider* dpp, User* u,
                           const rgw_bucket& b, std::unique_ptr<Bucket>* bucket,
                           optional_yield y) {
-  if (u) {
-    ldpp_dout(dpp, 20) << "DEBUG: get_bucket1: User: " << u->get_id() << dendl;
-  }
-  else {
-    ldpp_dout(dpp, 20) << "DEBUG: get_bucket1: User: (nullptr)" << dendl;
-  }
+  ldpp_dout(dpp, 20) << "DEBUG: get_bucket1: User: " << u << dendl;
   int ret;
   Bucket* bp;
 

--- a/src/rgw/rgw_sal_daos.cc
+++ b/src/rgw/rgw_sal_daos.cc
@@ -1254,6 +1254,7 @@ int DaosObject::get_obj_state(const DoutPrefixProvider* dpp,
                      << dendl;
   etag_bl.append(etag);
   state.attrset[RGW_ATTR_ETAG] = etag_bl;
+  *_state = &state;
 
   return 0;
 }
@@ -2866,7 +2867,12 @@ std::unique_ptr<Object> DaosStore::get_object(const rgw_obj_key& k) {
 int DaosStore::get_bucket(const DoutPrefixProvider* dpp, User* u,
                           const rgw_bucket& b, std::unique_ptr<Bucket>* bucket,
                           optional_yield y) {
-  ldpp_dout(dpp, 20) << "DEBUG: get_bucket1: User" << u->get_id() << dendl;
+  if (u) {
+    ldpp_dout(dpp, 20) << "DEBUG: get_bucket1: User: " << u->get_id() << dendl;
+  }
+  else {
+    ldpp_dout(dpp, 20) << "DEBUG: get_bucket1: User: (nullptr)" << dendl;
+  }
   int ret;
   Bucket* bp;
 

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -185,6 +185,11 @@ class DaosBucket : public Bucket {
 
   DaosBucket(DaosStore* _st) : store(_st), acls() {}
 
+  DaosBucket(const DaosBucket& _daos_bucket) : store(_daos_bucket.store), acls(), coh(DAOS_HDL_INVAL), dfs(nullptr) {
+    //TODO: deep copy all objects
+    //daos_duplicate_handle(_daos_bucket.coh);
+  }
+
   DaosBucket(DaosStore* _st, User* _u) : Bucket(_u), store(_st), acls() {}
 
   DaosBucket(DaosStore* _st, const rgw_bucket& _b)
@@ -267,7 +272,7 @@ class DaosBucket : public Bucket {
                               uint64_t timeout) override;
   virtual int purge_instance(const DoutPrefixProvider* dpp) override;
   virtual std::unique_ptr<Bucket> clone() override {
-    return std::make_unique<DaosBucket>(*this);
+    return std::unique_ptr<DaosBucket>(new DaosBucket(*this));
   }
   virtual std::unique_ptr<MultipartUpload> get_multipart_upload(
       const std::string& oid,


### PR DESCRIPTION
Added copy constructor for DaosBucket


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
