### PR TITLE
Add git pull capabilities; improve restarting DAOS

### DIFF
--- a/src/daos/docker/ceph/Dockerfile
+++ b/src/daos/docker/ceph/Dockerfile
@@ -13,9 +13,9 @@ LABEL maintainer="seagate-daos@seagate.com"
 COPY ccache.conf /etc/ccache.conf
 RUN cd /opt && sudo mkdir -p ceph && sudo chmod 777 ceph && git clone --recurse https://github.com/zalsader/ceph --branch add-daos-rgw-sal
 RUN cd /opt/ceph && ./install-deps.sh
+RUN pip3 install cython prettytable
 RUN cd /opt/ceph && cmake3 -GNinja -DPC_DAOS_INCLUDEDIR=${DAOS_PATH}/include -DPC_DAOS_LIBDIR=${DAOS_PATH}/lib64 -DWITH_PYTHON3=3.6 -DWITH_RADOSGW_DAOS=YES -DWITH_CCACHE=ON -DENABLE_GIT_VERSION=OFF -B build && cd build && ninja vstart
 RUN cd /opt/ceph/build && sudo MDS=0 RGW=1 ../src/vstart.sh -f -n --without-dashboard
 RUN cd /opt/ceph/build && sudo ../src/stop.sh
 COPY ceph.sed /opt/ceph/build
 RUN cd /opt/ceph/build && sed -i -f ceph.sed ceph.conf
-#RUN cd /opt/ceph/build && sudo MDS=0 RGW=1 ../src/vstart.sh --without-dashboard


### PR DESCRIPTION
Fix DAOS restart issues
Add git pull with building all subsequent targets
 no change=no images built
 s3-tests changes=s3-tests rebuilt
 ceph changes: ceph/s3-tests rebuilt
 daos changes: daos/ceph/s3-tests rebuilt


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
