### PR TITLE
Fix color output of NOCOLOR when disabled

### DIFF
--- a/src/daos/color_output.sh
+++ b/src/daos/color_output.sh
@@ -107,6 +107,14 @@ get_status_color()
     fi
 }
 
+get_restore_color()
+{
+    require_variables color_output
+    if [[ $color_output == true ]]; then
+        echo $NOCCOLOR
+    fi
+}
+
 get_count_color()
 {
     require_variables color_output

--- a/src/daos/docker/s3-tests/run_tests.sh
+++ b/src/daos/docker/s3-tests/run_tests.sh
@@ -53,8 +53,10 @@ function usage()
     echo -e "\t\tStart the test run at numbered test"
     echo -e "\t--end=$ACCEPTABLE_INTEGER_REGEX default=1000000"
     echo -e "\t\tEnd the test run at numbered test"
-    echo -e "\t-t--debug-script=$BOOLEAN_VALUES default=0"
+    echo -e "\t--debug-script=$BOOLEAN_VALUES default=false"
     echo -e "\t\tSkip execution of each test"
+    echo -e "\t--color-output=$BOOLEAN_VALUES default=TRUE"
+    echo -e "\t\tShow ANSI color codes for status/execution time"
     echo -e "\t--verbose"
     echo -e "\t\tEcho commands"
     echo ""
@@ -331,8 +333,9 @@ run_test()
     EXECUTIONTIMECOLOR=$(get_execution_time_color $execution_time)
     execution_count=`echo $count_time | sed "s/^\(.*\),.*$/\1/"`
     COUNTCOLOR=$(get_count_color $execution_count)
+    RESTORECOLOR=$(get_restore_color)
 
-    echo -e " ${COUNTCOLOR}count=$execution_count$NOCCOLOR ${EXECUTIONTIMECOLOR}time=$execution_time$NOCCOLOR ${RESULTCOLOR}result=$testresult$NOCCOLOR $testfile"
+    echo -e " ${COUNTCOLOR}count=$execution_count${RESTORECOLOR} ${EXECUTIONTIMECOLOR}time=$execution_time${RESTORECOLOR} ${RESULTCOLOR}result=$testresult${RESTORECOLOR} $testfile"
     if [[ $count_time == '' ]];
     then
         echo "Test failed - count_time should never be empty: $testfile"


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
