### PR TITLE
Fix the bucket creation script to use CEPH_PATH

### DIFF
--- a/src/daos/docker/s3-tests/setup.sh
+++ b/src/daos/docker/s3-tests/setup.sh
@@ -3,16 +3,16 @@
 # create conf file from s3tests.conf.SAMPLE
 # prepare the tests
 
-# source $CEPH_PATH/src/daos/silent_pushd_popd.sh
+source $CEPH_PATH/src/daos/silent_pushd_popd.sh
 
-if [[ ! "$ceph_folder" =~ . ]];
+if [[ ! "$CEPH_PATH" =~ . ]];
 then
-    ceph_folder=/opt/ceph
+    CEPH_PATH=/opt/ceph
 fi
 
 user_file=$(mktemp /tmp/john.doe.XXXXXXXXX.json)
 
-pushd ${ceph_folder}/build
+pushd ${CEPH_PATH}/build
 sudo bin/radosgw-admin user create --email johndoe@dgw.com --uid johndoe --display-name John-Doe --no-mon-config > $user_file
 if [ $? -ne 0 ]; then
     sudo bin/radosgw-admin user info --uid johndoe > $user_file

--- a/src/daos/docker/s3-tests/setup.sh
+++ b/src/daos/docker/s3-tests/setup.sh
@@ -5,11 +5,6 @@
 
 source $CEPH_PATH/src/daos/silent_pushd_popd.sh
 
-if [[ ! "$CEPH_PATH" =~ . ]];
-then
-    CEPH_PATH=/opt/ceph
-fi
-
 user_file=$(mktemp /tmp/john.doe.XXXXXXXXX.json)
 
 pushd ${CEPH_PATH}/build


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
