### PR TITLE
Fix syntax errors and logic for ccache.conf

### DIFF
--- a/src/daos/build/install-single-host-dgw.sh
+++ b/src/daos/build/install-single-host-dgw.sh
@@ -138,13 +138,23 @@ function assign_path()
     export $1=$ASSIGN_PATH
 }
 
+function append_ccache_source_date()
+{
+    set +e
+    grep "SOURCE_DATE_EPOCH" ~/.bashrc
+    if [[ ! $? == 0 ]]; then
+        echo "export SOURCE_DATE_EPOCH=946684800" >> ~/.bashrc
+    fi
+    set -e
+}
+
 function search_first_word_and_append_to_ccache()
 {
     local first_word=$(echo $1 | cut -d " " -f 1)
     set +e
-    grep "^${firstword}" <<< $1
+    grep "^${first_word}" /etc/ccache.conf
     if [[ ! $? == 0 ]]; then
-        sudo bash -c 'echo "$1" >> /etc/ccache.conf'
+        sudo bash -c "echo \"$1\" >> /etc/ccache.conf"
     fi
     set -e
 }
@@ -232,7 +242,7 @@ build_ceph()
     search_first_word_and_append_to_ccache "max_size = 25G"
     search_first_word_and_append_to_ccache "sloppiness = time_macros"
     search_first_word_and_append_to_ccache "run_second_cpp = true"
-    echo "export SOURCE_DATE_EPOCH=946684800" >> ~/.bashrc
+    append_ccache_source_date
     cmake3 -GNinja -DPC_DAOS_INCLUDEDIR=${DAOS_PATH}/install/include -DPC_DAOS_LIBDIR=${DAOS_PATH}/install/lib64 -DWITH_PYTHON3=3.6 -DWITH_RADOSGW_DAOS=YES -DWITH_CCACHE=ON -DENABLE_GIT_VERSION=OFF -B build
     cd build
     ninja vstart


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
